### PR TITLE
Enhance ETL Pipeline with Explicit AWS Credential Management

### DIFF
--- a/short_to_long_pipeline/etl_pipeline.py
+++ b/short_to_long_pipeline/etl_pipeline.py
@@ -29,8 +29,28 @@ DB_CONFIG = {
     "port": os.getenv("DB_PORT")
 }
 
+AWS_CREDENTIALS = {
+    "aws_access_key_id": os.getenv("ACCESS_KEY_ID"),
+    "aws_secret_access_key": os.getenv("SECRET_ACCESS_KEY"),
+    "region_name": os.getenv("AWS_REGION", "eu-west-2"),
+}
+
 S3_BUCKET = os.getenv("S3_BUCKET")
 S3_KEY_PREFIX = os.getenv("S3_KEY", "plant_data/")
+
+
+def get_aws_client(service_name: str) -> boto3.client:
+    """Creates a Boto3 client using credentials from .env."""
+    try:
+        client = boto3.client(service_name, **AWS_CREDENTIALS)
+        logging.info("AWS client for %s created successfully.", service_name)
+        return client
+    except NoCredentialsError as e:
+        logging.error("AWS credentials not found: %s", e)
+        raise
+    except PartialCredentialsError as e:
+        logging.error("Incomplete AWS credentials: %s", e)
+        raise
 
 
 def get_db_connection() -> pymssql.Connection:
@@ -90,7 +110,7 @@ def save_to_parquet(dataframe: pd.DataFrame, file_date: str) -> None:
 def upload_to_s3(parquet_file: str, bucket: str, s3_key: str) -> None:
     """Uploads a local file to S3."""
     try:
-        s3_client = boto3.client("s3")
+        s3_client = get_aws_client("s3")
         s3_client.upload_file(parquet_file, bucket, s3_key)
         logging.info(
             "File successfully uploaded to S3 bucket '%s' with key '%s'.", bucket, s3_key


### PR DESCRIPTION
As a Data Engineer,
I want to explicitly configure AWS credentials and client initialization in the ETL pipeline,
so that the pipeline reliably uploads Parquet files to S3 using the correct credentials from a .env file.

