### PR TITLE
fixed typos in run_pipeline

### DIFF
--- a/rds_to_s3_pipeline/etl_pipeline.py
+++ b/rds_to_s3_pipeline/etl_pipeline.py
@@ -164,13 +164,10 @@ def run_pipeline():
     if os.path.exists(parquet_file):
         os.remove(parquet_file)
         logging.info("Temporary Parquet file removed: %s",
-                     PARQUET_FILE)
+                     parquet_file)
 
-    clear_rds(db_connection)
-
-                     
+    clear_rds(connection)
 
 
 if __name__ == "__main__":
     run_pipeline()
-


### PR DESCRIPTION
At the end of the run_pipeline function the parquet_file variable was called as PARQUET_FILE and the connection variable was called as db_connection.