### PR TITLE
updated to task definition

### DIFF
--- a/rds_to_s3_dockerfile
+++ b/rds_to_s3_dockerfile
@@ -4,6 +4,6 @@ COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt
 
-COPY short_to_long_pipeline/etl_pipeline.py .
+COPY rds_to_s3_pipeline/etl_pipeline.py .
 
 CMD ["python3", "etl_pipeline.py"] 

--- a/rds_to_s3_pipeline/etl_pipeline.py
+++ b/rds_to_s3_pipeline/etl_pipeline.py
@@ -151,9 +151,9 @@ def run_pipeline():
     connection = get_db_connection()
     complete_dataframe = load_data_to_dataframe(connection)
 
-    curent_date = datetime.now().strftime("%Y-%m-%d")
-    parquet_file = save_to_parquet(complete_dataframe, curent_date)
-    s3_key = f"{S3_KEY_PREFIX}{curent_date}.parquet"
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    parquet_file = save_to_parquet(complete_dataframe, current_date)
+    s3_key = f"{S3_KEY_PREFIX}{current_date}.parquet"
 
     if not isinstance(parquet_file, str):
         raise ValueError(f"""Expected string for local file, got {

--- a/terraform/eventbridge.tf
+++ b/terraform/eventbridge.tf
@@ -10,7 +10,7 @@ resource "aws_scheduler_schedule" "pipeline_schedule" {
     arn = "arn:aws:ecs:eu-west-2:129033205317:cluster/c14-ecs-cluster"
     role_arn = aws_iam_role.eventbridge_role.arn
     ecs_parameters {
-        task_definition_arn = "arn:aws:ecs:eu-west-2:129033205317:task-definition/c14-team-growth-rds-to-s3-etl:4"
+        task_definition_arn = "arn:aws:ecs:eu-west-2:129033205317:task-definition/c14-team-growth-rds-to-s3-etl:7"
         launch_type = "FARGATE"  
         network_configuration {
             subnets = [


### PR DESCRIPTION
Now points to the latest task definition version (c14-team-growth-rds-to-s3-etl:7). Also updated the rds_to_s3_dockerfile to match the new folder names. Fixed some typos in the etl_pipeline.py file.