### PR TITLE
fixed etl_pipeline.py

### DIFF
--- a/rds_to_s3_pipeline/etl_pipeline.py
+++ b/rds_to_s3_pipeline/etl_pipeline.py
@@ -11,7 +11,7 @@ This script performs the following steps as part of an ETL pipeline:
 # pylint: disable=no-member
 import os
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 import boto3
 import pymssql
 import pandas as pd
@@ -149,9 +149,9 @@ def run_pipeline():
     connection = get_db_connection()
     complete_dataframe = load_data_to_dataframe(connection)
 
-    current_date = datetime.now().strftime("%Y-%m-%d")
-    parquet_file = save_to_parquet(complete_dataframe, current_date)
-    s3_key = f"{S3_KEY_PREFIX}{current_date}.parquet"
+    yesterday = (datetime.now() - timedelta(1)).strftime("%Y-%m-%d")
+    parquet_file = save_to_parquet(complete_dataframe, yesterday)
+    s3_key = f"{S3_KEY_PREFIX}{yesterday}.parquet"
 
     if not isinstance(parquet_file, str):
         raise ValueError(f"""Expected string for local file, got {

--- a/rds_to_s3_pipeline/etl_pipeline.py
+++ b/rds_to_s3_pipeline/etl_pipeline.py
@@ -87,8 +87,6 @@ def load_data_to_dataframe(db_connection: pymssql.Connection) -> pd.DataFrame:
     try:
         dataframe = pd.read_sql(query, db_connection)
         logging.info("Data successfully loaded into DataFrame.")
-        db_connection.close()
-        logging.info("Database connection closed.")
         return dataframe
     except pymssql.DatabaseError as e:
         logging.error("Database error during data extraction: %s", e)
@@ -96,14 +94,14 @@ def load_data_to_dataframe(db_connection: pymssql.Connection) -> pd.DataFrame:
 
 
 def clear_rds(db_connection: pymssql.Connection) -> None:
-    query = "TRUNCATE TABLE gamma.recordings;"
+    query = "TRUNCATE TABLE gamma.recording;"
 
     try:
         with db_connection.cursor() as cursor:
             cursor.execute(query)
             db_connection.commit()
         logging.info(
-            "All gamma.recordings table successfully dropped from the database.")
+            "The gamma.recording table successfully dropped from the database.")
     except pymssql.DatabaseError as e:
         logging.error("Database error during table deletion: %s", e)
         raise
@@ -167,6 +165,8 @@ def run_pipeline():
                      parquet_file)
 
     clear_rds(connection)
+    connection.close()
+    logging.info("Database connection closed.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the query the correct table wasn't being truncated; gamma.recordings instead of gamma.recording.
Also the connection to the database was being closed before the table could be truncated.
Have run the code successfully locally and rebuilt and pushed to the mini etl ecr. 